### PR TITLE
Add german translation

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -18,7 +18,7 @@
       },
       "auto-pause": {
         "name": "Automatisches Pausieren",
-        "hint": "Pausiert das Spiel automatisch, wenn das Spielpausefenster geöffnet wird."
+        "hint": "Pausiert das Spiel automatisch, wenn das Spielpausefenster geöffnet wird"
       },
       "show-button": {
         "name": "Schaltfläche anzeigen",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1,0 +1,43 @@
+{
+  "BREAKTIME": {
+    "app": {
+      "title": "Spielpause!",
+      "breaktime": "Spielpause",
+      "away": "Ich bin kurz weg.",
+      "back": "Ich bin wieder da.",
+      "chataway": "Kurz weggehen",
+      "chatback": "Zum Spiel zurückkehren",
+      "playerisaway": "Der Spieler ist zur Zeit abwesend",
+      "LeaveAgain": "Noch mal weggehen",
+      "ImBack": "Ich bin wieder da"
+    },
+    "setting": {
+      "hot-keys": {
+        "name": "Tastenbelegung ändern",
+        "hint": "Ändere die Tastenbelegung für dieses Modul"
+      },
+      "auto-pause": {
+        "name": "Automatisches Pausieren",
+        "hint": "Pausiert das Spiel automatisch, wenn das Spielpausefenster geöffnet wird."
+      },
+      "show-button": {
+        "name": "Schaltfläche anzeigen",
+        "hint": "Schaltfläche in der Spielerübersicht anzeigen"
+      },
+      "away-text": {
+        "name": "Nachricht beim Weggehen"
+      },
+      "back-text": {
+        "name": "Nachricht beim Zurückkommen"
+      }
+    },
+    "hotkey": {
+      "label": "BreakTime, Pausetaste",
+      "description": "Benutze diese Taste um eine Spielpause zu beginnen",
+      "pausekey": "Pausetaste"
+    },
+    "button": {
+      "title": "Kurz weggehen"
+    }
+  }
+}

--- a/module.json
+++ b/module.json
@@ -17,6 +17,11 @@
 	"socket": true,
 	"languages": [
 		{
+			"lang": "de",
+			"name": "Deutsch",
+			"path": "lang/de.json"
+		},
+		{
 			"lang": "en",
 			"name": "English",
 			"path": "lang/en.json"


### PR DESCRIPTION
I couldn't find where the hotkey label was used, so I kept "BreakTime", since I assume it's for filtering or finding the correct hotkeys and it would be nice to find it by the actual module name.